### PR TITLE
Separation of status commands from go pro module

### DIFF
--- a/camera.go
+++ b/camera.go
@@ -1,0 +1,110 @@
+package gogopro
+
+import ()
+
+type Camera struct {
+	APIRequester   *APIRequester
+	StatusCommands map[string]StatusCommand
+}
+
+func (c *Camera) Init() *Camera {
+	return c
+}
+
+func CreateCamera(APIRequester *APIRequester) *Camera {
+	camera := &Camera{}
+	camera.APIRequester = APIRequester
+	statusCommands := CreateCameraStatusCommands()
+	camera.StatusCommands = statusCommands
+	return camera
+}
+
+func CreateCameraStatusCommands() map[string]StatusCommand {
+	sc := make(map[string]StatusCommand)
+	sc["mode"] = StatusCommand{
+		Endpoint:   "/camera/sx",
+		ResultByte: 1,
+		Translaters: []StatusTranslater{
+			StatusTranslater{
+				Result:         0,
+				ExpectedReturn: "video"},
+			StatusTranslater{
+				Result:         1,
+				ExpectedReturn: "photo"},
+			StatusTranslater{
+				Result:         2,
+				ExpectedReturn: "burst"},
+			StatusTranslater{
+				Result:         3,
+				ExpectedReturn: "timelapse"}}}
+	sc["defaultmode"] = StatusCommand{
+		Endpoint:   "/camera/sx",
+		ResultByte: 3,
+		Translaters: []StatusTranslater{
+			StatusTranslater{
+				Result:         0,
+				ExpectedReturn: "video"},
+			StatusTranslater{
+				Result:         1,
+				ExpectedReturn: "photo"},
+			StatusTranslater{
+				Result:         2,
+				ExpectedReturn: "burst"},
+			StatusTranslater{
+				Result:         3,
+				ExpectedReturn: "timelapse"}}}
+	sc["spotmeter"] = StatusCommand{
+		Endpoint:   "/camera/sx",
+		ResultByte: 4,
+		Translaters: []StatusTranslater{
+			StatusTranslater{
+				Result:         0,
+				ExpectedReturn: "off"},
+			StatusTranslater{
+				Result:         1,
+				ExpectedReturn: "on"}}}
+	sc["timelapse_interval"] = StatusCommand{
+		Endpoint:   "/camera/sx",
+		ResultByte: 5,
+		Translaters: []StatusTranslater{
+			StatusTranslater{
+				Result:         0,
+				ExpectedReturn: "0.5s"},
+			StatusTranslater{
+				Result:         1,
+				ExpectedReturn: "1s"},
+			StatusTranslater{
+				Result:         2,
+				ExpectedReturn: "2s"},
+			StatusTranslater{
+				Result:         5,
+				ExpectedReturn: "5s"},
+			StatusTranslater{
+				Result:         10,
+				ExpectedReturn: "10s"},
+			StatusTranslater{
+				Result:         40,
+				ExpectedReturn: "30s"},
+			StatusTranslater{
+				Result:         60,
+				ExpectedReturn: "60s"}}}
+	sc["iso_sharpness"] = StatusCommand{
+		Endpoint:   "/camera/sx",
+		ResultByte: 6,
+		Translaters: []StatusTranslater{
+			StatusTranslater{
+				Result:         0,
+				ExpectedReturn: "off"},
+			StatusTranslater{
+				Result:         1,
+				ExpectedReturn: "on"}}}
+	return sc
+}
+
+func (c *Camera) GetMode() (string, error) {
+	result, err := c.StatusCommands["mode"].RunStatusCommand(c.APIRequester)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}

--- a/cli/main.go
+++ b/cli/main.go
@@ -6,10 +6,14 @@ import (
 )
 
 func main() {
-	gopro, err := gopro.CreateGoPro("10.5.5.9").Init()
+	gopro, err := gogopro.CreateGoPro("10.5.5.9").Init()
 	if err != nil {
 		panic(err)
 	}
-	status, err := gopro.Status()
+	fmt.Println(gopro)
+	status, err := (*gopro.Power).GetPowerStatus()
+	if err != nil {
+		panic(err)
+	}
 	fmt.Println(status)
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -16,4 +16,10 @@ func main() {
 		panic(err)
 	}
 	fmt.Println(status)
+
+	status, err := (*gopro.Camera).GetMode()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(status)
 }

--- a/gopro.go
+++ b/gopro.go
@@ -1,4 +1,4 @@
-package gopro
+package gogopro
 
 import (
 	"log"
@@ -11,7 +11,7 @@ type BasicAuth struct {
 }
 
 type GoPro struct {
-	APIRequester *APIRequester
+	Power *Power
 }
 
 var (
@@ -24,7 +24,7 @@ func (gopro *GoPro) Init() (*GoPro, error) {
 	client := &http.Client{
 		CheckRedirect: nil,
 	}
-	gopro.APIRequester.Client = client
+	gopro.Power.APIRequester.Client = client
 	return gopro, nil
 }
 
@@ -44,28 +44,16 @@ func (gopro *GoPro) initLogger() {
 
 func CreateGoPro(Ipaddr string, auth ...interface{}) *GoPro {
 	gopro := &GoPro{}
-	gopro.APIRequester = &APIRequester{URL: "http://" + Ipaddr}
+	APIRequester := &APIRequester{URL: "http://" + Ipaddr}
 
 	if len(auth) == 1 {
-		gopro.APIRequester.BasicAuth = &BasicAuth{Password: auth[0].(string)}
+		APIRequester.BasicAuth = &BasicAuth{Password: auth[0].(string)}
 	} else {
-		gopro.APIRequester.BasicAuth = &BasicAuth{Password: ""}
+		APIRequester.BasicAuth = &BasicAuth{Password: ""}
 	}
+
+	power := CreatePower(APIRequester).Init()
+	gopro.Power = power
+
 	return gopro
-}
-
-func (gopro *GoPro) Status() (*http.Response, error) {
-	resp, err := gopro.APIRequester.getWithPort("", 8080)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (gopro *GoPro) GetPowerStatus() (*http.Response, error) {
-	resp, err := gopro.APIRequester.get("/bacpac/se")
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
 }

--- a/gopro.go
+++ b/gopro.go
@@ -11,7 +11,8 @@ type BasicAuth struct {
 }
 
 type GoPro struct {
-	Power *Power
+	Power  *Power
+	Camera *Camera
 }
 
 var (
@@ -25,6 +26,7 @@ func (gopro *GoPro) Init() (*GoPro, error) {
 		CheckRedirect: nil,
 	}
 	gopro.Power.APIRequester.Client = client
+	gopro.Camera.APIRequester.Client = client
 	return gopro, nil
 }
 
@@ -54,6 +56,9 @@ func CreateGoPro(Ipaddr string, auth ...interface{}) *GoPro {
 
 	power := CreatePower(APIRequester).Init()
 	gopro.Power = power
+
+	camera := CreateCamera(APIRequester).Init()
+	gopro.Camera = camera
 
 	return gopro
 }

--- a/power.go
+++ b/power.go
@@ -14,12 +14,12 @@ func (p *Power) Init() *Power {
 func CreatePower(APIRequester *APIRequester) *Power {
 	power := &Power{}
 	power.APIRequester = APIRequester
-	statusCommands := CreateStatusCommands()
+	statusCommands := CreatePowerStatusCommands()
 	power.StatusCommands = statusCommands
 	return power
 }
 
-func CreateStatusCommands() map[string]StatusCommand {
+func CreatePowerStatusCommands() map[string]StatusCommand {
 	sc := make(map[string]StatusCommand)
 	sc["power"] = StatusCommand{Endpoint: "/bacpac/se", ResultByte: -1,
 		Translaters: []StatusTranslater{

--- a/power.go
+++ b/power.go
@@ -1,11 +1,10 @@
 package gogopro
 
-import (
-	"io/ioutil"
-)
+import ()
 
 type Power struct {
-	APIRequester *APIRequester
+	APIRequester   *APIRequester
+	StatusCommands map[string]StatusCommand
 }
 
 func (p *Power) Init() *Power {
@@ -15,18 +14,28 @@ func (p *Power) Init() *Power {
 func CreatePower(APIRequester *APIRequester) *Power {
 	power := &Power{}
 	power.APIRequester = APIRequester
+	statusCommands := CreateStatusCommands()
+	power.StatusCommands = statusCommands
 	return power
 }
 
+func CreateStatusCommands() map[string]StatusCommand {
+	sc := make(map[string]StatusCommand)
+	sc["power"] = StatusCommand{Endpoint: "/bacpac/se", ResultByte: -1,
+		Translaters: []StatusTranslater{
+			StatusTranslater{
+				Result:         0,
+				ExpectedReturn: "off"},
+			StatusTranslater{
+				Result:         1,
+				ExpectedReturn: "on"}}}
+	return sc
+}
+
 func (p *Power) GetPowerStatus() (string, error) {
-	resp, err := p.APIRequester.get("/bacpac/se")
+	result, err := p.StatusCommands["power"].RunStatusCommand(p.APIRequester)
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if body[len(body)-1] == 0 {
-		return "off", nil
-	}
-	return "on", nil
+	return result, nil
 }

--- a/power.go
+++ b/power.go
@@ -1,0 +1,32 @@
+package gogopro
+
+import (
+	"io/ioutil"
+)
+
+type Power struct {
+	APIRequester *APIRequester
+}
+
+func (p *Power) Init() *Power {
+	return p
+}
+
+func CreatePower(APIRequester *APIRequester) *Power {
+	power := &Power{}
+	power.APIRequester = APIRequester
+	return power
+}
+
+func (p *Power) GetPowerStatus() (string, error) {
+	resp, err := p.APIRequester.get("/bacpac/se")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if body[len(body)-1] == 0 {
+		return "off", nil
+	}
+	return "on", nil
+}

--- a/request.go
+++ b/request.go
@@ -1,6 +1,7 @@
-package gopro
+package gogopro
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 )

--- a/status_command.go
+++ b/status_command.go
@@ -1,0 +1,50 @@
+package gogopro
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+)
+
+type StatusTranslater struct {
+	Result         byte
+	ExpectedReturn string
+}
+
+type StatusCommand struct {
+	Endpoint    string
+	ResultByte  int
+	Translaters []StatusTranslater
+}
+
+func (s StatusCommand) RunStatusCommand(APIRequester *APIRequester) (string, error) {
+	resp, err := APIRequester.get(s.Endpoint)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	result, err := s.EvalTranslater(body)
+	if err != nil {
+		return "", err
+	}
+	return result, nil
+}
+
+func (s StatusCommand) EvalTranslater(result []byte) (string, error) {
+	fmt.Println(len(result))
+	fmt.Println(result)
+	found_result := byte(0)
+	if s.ResultByte == -1 {
+		found_result = result[len(result)-1]
+	} else {
+		found_result = result[s.ResultByte]
+	}
+
+	for _, translater := range s.Translaters {
+		if translater.Result == found_result {
+			return translater.ExpectedReturn, nil
+		}
+	}
+	return "", errors.New(fmt.Sprintf("Failed to find a expected return val for result %d", found_result))
+}

--- a/util.go
+++ b/util.go
@@ -1,4 +1,4 @@
-package gopro
+package gogopro
 
 import (
 	"strings"


### PR DESCRIPTION
Separate power status/commands into separate module
- Power functions and status will be in a separate module and will be
  available to an GoPro object.

Move status command to generic object
- The StatusCommand type now runs api command and determines the
  correct value to return.
- The Power type will create predetermined StatusCommands with
  translaters. Power functions will use the correct StatusCommand
  matching the function called.

Add camera module
- Add status_command to execute status queries.
- Add some camera status commands